### PR TITLE
Add async methods for submitting and awaiting calls in PocketIcClient

### DIFF
--- a/src/ic_mple_client/src/pocket_ic.rs
+++ b/src/ic_mple_client/src/pocket_ic.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use candid::utils::ArgumentEncoder;
 use candid::{CandidType, Decode, Principal};
+use pocket_ic::common::rest::RawMessageId;
 use pocket_ic::nonblocking::*;
 use serde::de::DeserializeOwned;
 
@@ -72,6 +73,29 @@ impl PocketIcClient {
             .query_call(self.canister, self.caller, method, args)
             .await?;
 
+        let decoded = Decode!(&call_result, R)?;
+        Ok(decoded)
+    }
+
+    pub async fn submit_call<T>(&self, method: &str, args: T) -> CanisterClientResult<RawMessageId>
+    where
+        T: ArgumentEncoder + Send + Sync,
+    {
+        let args = candid::encode_args(args)?;
+
+        let msg_id = self
+            .client()
+            .submit_call(self.canister, self.caller, method, args)
+            .await?;
+
+        Ok(msg_id)
+    }
+
+    pub async fn await_call<R>(&self, msg_id: RawMessageId) -> CanisterClientResult<R>
+    where
+        R: DeserializeOwned + CandidType,
+    {
+        let call_result = self.client().await_call(msg_id).await?;
         let decoded = Decode!(&call_result, R)?;
         Ok(decoded)
     }

--- a/src/ic_mple_client/src/pocket_ic.rs
+++ b/src/ic_mple_client/src/pocket_ic.rs
@@ -77,6 +77,7 @@ impl PocketIcClient {
         Ok(decoded)
     }
 
+    /// Submit an update call (without executing it immediately).
     pub async fn submit_call<T>(&self, method: &str, args: T) -> CanisterClientResult<RawMessageId>
     where
         T: ArgumentEncoder + Send + Sync,
@@ -91,6 +92,7 @@ impl PocketIcClient {
         Ok(msg_id)
     }
 
+    /// Await an update call submitted previously by `submit_call`.
     pub async fn await_call<R>(&self, msg_id: RawMessageId) -> CanisterClientResult<R>
     where
         R: DeserializeOwned + CandidType,


### PR DESCRIPTION
Due to this [document](https://github.com/dfinity/ic/blob/HEAD/packages/pocket-ic/HOWTO.md#concurrent-update-calls). I think it is make sense to have these two methods in PocketIcClient

Previous if we using `update_call` it is very hard to replicated the concurrency in short period of time

Relate forum topics:
- https://forum.dfinity.org/t/regarding-concurrency-testing-using-pocketic/42944
- https://forum.dfinity.org/t/pocketic-concurrency-testing-simulate-multiple-users-performing-transactions-simultaneously/41449
